### PR TITLE
Add Window.SetTitle feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ packages/
 TestResults/
 
 # globs
+.vs/
 Makefile.in
 *.DS_Store
 *.sln.cache

--- a/AivDraw/Window.cs
+++ b/AivDraw/Window.cs
@@ -155,6 +155,15 @@ namespace Aiv.Draw
 		}
 
 		/// <summary>
+		/// Sets Window's Title
+		/// </summary>
+		/// <param name="text">text to be set as window title</param>
+		public void SetTitle(string text)
+		{
+			this.form.Text = text;
+		}
+
+		/// <summary>
 		/// Creates a new Window
 		/// </summary>
 		/// <param name="width">internal window's width</param>

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ byte []bitmap = hero.bitmap;
 int width = hero.width;
 int height = hero.height;
 ```
+
+You can update Window title like this:
+
+```csharp
+window.SetTitle("Your new title");
+```


### PR DESCRIPTION
Window.SetTitle in order to update window title during game loop.

This to avoid to print FPS / deltaTime and other small info engine related on the console.