### PR TITLE
Exclude regex tag from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ notifications:
     if: branch = master
     on_success: true
     on_failure: true
-branches:
+tags:
   except:    
+    #- /^\d+(\.\d+){2,3}$/
     - prova
-    
 before_script:
   - export AUTO_PATH_SLN=AivDraw.sln
   - export AUTO_PATH_LIBR_DLL=AivDraw/bin/Release/AivDraw.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
 branches:
   except:    
     - prova
+    
 before_script:
   - export AUTO_PATH_SLN=AivDraw.sln
   - export AUTO_PATH_LIBR_DLL=AivDraw/bin/Release/AivDraw.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ notifications:
     if: branch = master
     on_success: true
     on_failure: true
-tags:
-  except:    
-    #- /^\d+(\.\d+){2,3}$/
-    - prova
 before_script:
   - export AUTO_PATH_SLN=AivDraw.sln
   - export AUTO_PATH_LIBR_DLL=AivDraw/bin/Release/AivDraw.dll
@@ -19,6 +15,11 @@ before_script:
   - export AUTO_PATH_ARTIFACTS=artifacts
   - export AUTO_YEAR=$(date +%Y)
   - export AUTO_TAG=$(if [ -z "$TRAVIS_TAG" ]; then echo "0.0.0"; else echo $TRAVIS_TAG; fi) 
+  # Need to stop build if TAG is not like X.Y.Z(.A)
+  # Workaround becase doesn't exists TAG EXCLUSION mechanism for build
+  # https://docs.travis-ci.com/user/customizing-the-build#using-regular-expressions
+  - export AUTO_TAG_REGEX="^[0-9]+(\.[0-9]+){2,3}$"
+  - if [[ ! $AUTO_TAG =~ $AUTO_TAG_REGEX ]]; then echo "Tag is not valid. Build will be terminated" && travis_terminate 1; fi
 script:
   - echo "=== INSTALL ==="
     && nuget restore $AUTO_PATH_SLN
@@ -47,6 +48,7 @@ deploy:
     script: nuget push ./*.nupkg -Verbosity detailed -ApiKey $NUGET_API_KEY -Source $NUGET_SOURCE
     on:
       tags: true
+      condition: $TRAVIS_TAG =~ ^\d+(\.\d+){2,3}$
     skip_cleanup: true
     
   - provider: pages
@@ -54,6 +56,7 @@ deploy:
     local_dir: $AUTO_PATH_DOCS
     on:
       tags: true
+      condition: $TRAVIS_TAG =~ ^\d+(\.\d+){2,3}$
     skip_cleanup: true
     
   - provider: releases
@@ -62,4 +65,5 @@ deploy:
     file: $AUTO_PATH_ARTIFACTS/*
     on:
       tags: true
+      condition: $TRAVIS_TAG =~ ^\d+(\.\d+){2,3}$
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   # Workaround becase doesn't exists TAG EXCLUSION mechanism for build
   # https://docs.travis-ci.com/user/customizing-the-build#using-regular-expressions
   - export AUTO_TAG_REGEX="^[0-9]+(\.[0-9]+){2,3}$"
-  - if [[ ! $AUTO_TAG =~ $AUTO_TAG_REGEX ]]; then echo "Tag is not valid. Build will be terminated" && travis_terminate 1; fi
+  - if [[ ! $AUTO_TAG =~ $AUTO_TAG_REGEX ]]; then echo "Tag '$AUTO_TAG' is not valid. Build will be terminated" && travis_terminate 1; fi
 script:
   - echo "=== INSTALL ==="
     && nuget restore $AUTO_PATH_SLN

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ notifications:
     if: branch = master
     on_success: true
     on_failure: true
+branches:
+  except:    
+    - prova
 before_script:
   - export AUTO_PATH_SLN=AivDraw.sln
   - export AUTO_PATH_LIBR_DLL=AivDraw/bin/Release/AivDraw.dll


### PR DESCRIPTION
Preventing build and releaseing on tagging that are not formatted X.Y.Z(.A)